### PR TITLE
Format go code using `goimport`

### DIFF
--- a/database/common.go
+++ b/database/common.go
@@ -9,12 +9,12 @@ import (
 var Db *gorm.DB
 
 type Commitment struct {
-	PollID        string
-	CreatedAt time.Time
-	VoterAddress      string
+	PollID       string
+	CreatedAt    time.Time
+	VoterAddress string
 	CommitHash   string
-  VoteOption  uint8
-	Salt   uint64
+	VoteOption   uint8
+	Salt         uint64
 }
 
 func InitDb(new_db *gorm.DB) {

--- a/database/query.go
+++ b/database/query.go
@@ -1,48 +1,49 @@
 package database
 
 import (
-  "encoding/hex"
-  "log"
-  "math/big"
-  "net/http"  
-  "github.com/gin-gonic/gin"
-  "github.com/miguelmota/go-solidity-sha3"
+	"encoding/hex"
+	"log"
+	"math/big"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/miguelmota/go-solidity-sha3"
 )
 
 type CommitmentBody struct {
-  PollID       string `json:"pollID"`
-  VoterAddress string `json:"voterAddress"`
-  CommitHash   string `json:"commitHash"`
-  VoteOption   int64  `json:"voteOption"`
-  Salt         int64  `json:"salt"`
+	PollID       string `json:"pollID"`
+	VoterAddress string `json:"voterAddress"`
+	CommitHash   string `json:"commitHash"`
+	VoteOption   int64  `json:"voteOption"`
+	Salt         int64  `json:"salt"`
 }
 
 func StoreCommitment(c *gin.Context) {
-  var commitmentBody CommitmentBody
-  c.BindJSON(&commitmentBody)
+	var commitmentBody CommitmentBody
+	c.BindJSON(&commitmentBody)
 
-  commitHash := solsha3.SoliditySHA3(
-    solsha3.Uint256(big.NewInt(commitmentBody.VoteOption)),
-    solsha3.Uint256(big.NewInt(commitmentBody.Salt)),
-  )
+	commitHash := solsha3.SoliditySHA3(
+		solsha3.Uint256(big.NewInt(commitmentBody.VoteOption)),
+		solsha3.Uint256(big.NewInt(commitmentBody.Salt)),
+	)
 
-  calculatedCommitHash := "0x" + hex.EncodeToString(commitHash)
-  if (calculatedCommitHash != commitmentBody.CommitHash) {
-    c.AbortWithStatus(http.StatusNotAcceptable)
-    return
-  }
+	calculatedCommitHash := "0x" + hex.EncodeToString(commitHash)
+	if calculatedCommitHash != commitmentBody.CommitHash {
+		c.AbortWithStatus(http.StatusNotAcceptable)
+		return
+	}
 
-  log.Printf("Storing commitment: %v %v %d %d (%v)", commitmentBody.PollID, commitmentBody.VoterAddress, commitmentBody.VoteOption, commitmentBody.Salt, commitmentBody.CommitHash)
+	log.Printf("Storing commitment: %v %v %d %d (%v)", commitmentBody.PollID, commitmentBody.VoterAddress, commitmentBody.VoteOption, commitmentBody.Salt, commitmentBody.CommitHash)
 
-  commitment := Commitment{
-    PollID:       commitmentBody.PollID,
-    VoterAddress: commitmentBody.VoterAddress,
-    CommitHash:   commitmentBody.CommitHash,
-    VoteOption:   uint8(commitmentBody.VoteOption),
-    Salt:         uint64(commitmentBody.Salt),
-  }
-  Db.Create(&commitment)
-  //Db.Debug().Create(&commitment)
-  
-  c.JSON(http.StatusCreated, gin.H{"message": "vote will be revealed when voting closes"})
+	commitment := Commitment{
+		PollID:       commitmentBody.PollID,
+		VoterAddress: commitmentBody.VoterAddress,
+		CommitHash:   commitmentBody.CommitHash,
+		VoteOption:   uint8(commitmentBody.VoteOption),
+		Salt:         uint64(commitmentBody.Salt),
+	}
+	Db.Create(&commitment)
+	//Db.Debug().Create(&commitment)
+
+	c.JSON(http.StatusCreated, gin.H{"message": "vote will be revealed when voting closes"})
 }

--- a/database/test.go
+++ b/database/test.go
@@ -14,10 +14,10 @@ func TestSetupData() {
 	a2 := common.HexToAddress("0x0022222222222222222222222222222222222222")
 	a3 := common.HexToAddress("0x0033333333333333333333333333333333333333")
 
-  c1 := Commitment{PollID: "Poll1", VoterAddress: a0.Hex(), CommitHash: "1234", VoteOption: 2, Salt: 666}
-  c2 := Commitment{PollID: "Poll1", VoterAddress: a1.Hex(), CommitHash: "4321", VoteOption: 2, Salt: 666}
-  c3 := Commitment{PollID: "Poll1", VoterAddress: a2.Hex(), CommitHash: "6789", VoteOption: 1, Salt: 666}
-  c4 := Commitment{PollID: "Poll1", VoterAddress: a3.Hex(), CommitHash: "9876", VoteOption: 1, Salt: 666}
+	c1 := Commitment{PollID: "Poll1", VoterAddress: a0.Hex(), CommitHash: "1234", VoteOption: 2, Salt: 666}
+	c2 := Commitment{PollID: "Poll1", VoterAddress: a1.Hex(), CommitHash: "4321", VoteOption: 2, Salt: 666}
+	c3 := Commitment{PollID: "Poll1", VoterAddress: a2.Hex(), CommitHash: "6789", VoteOption: 1, Salt: 666}
+	c4 := Commitment{PollID: "Poll1", VoterAddress: a3.Hex(), CommitHash: "9876", VoteOption: 1, Salt: 666}
 
 	Db.Create(&c1)
 	Db.Create(&c2)

--- a/events/events.go
+++ b/events/events.go
@@ -1,37 +1,37 @@
 package events
 
 import (
-  "context"
-  "encoding/hex"
-  "log"
-  "math/big"
-  "os"
-  "strings"
+	"context"
+	"encoding/hex"
+	"log"
+	"math/big"
+	"os"
+	"strings"
 
-  "github.com/TruSet/RevealerAPI/contract"
-  "github.com/TruSet/RevealerAPI/database"
+	"github.com/TruSet/RevealerAPI/contract"
+	"github.com/TruSet/RevealerAPI/database"
 
-  ethereum "github.com/ethereum/go-ethereum"
-  "github.com/ethereum/go-ethereum/accounts/abi"
-  "github.com/ethereum/go-ethereum/accounts/abi/bind"
-  "github.com/ethereum/go-ethereum/common"
-  "github.com/ethereum/go-ethereum/common/hexutil"
-  "github.com/ethereum/go-ethereum/core/types"
-  "github.com/ethereum/go-ethereum/ethclient"
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 
-  "github.com/miguelmota/go-solidity-sha3"
+	"github.com/miguelmota/go-solidity-sha3"
 )
 
 var (
-  commitRevealVotingContractAddress common.Address
-  filter                            ethereum.FilterQuery
-  votingSession                     *contract.TruSetCommitRevealVotingSession
-  boundContract                     *bind.BoundContract
-  from                              common.Address
+	commitRevealVotingContractAddress common.Address
+	filter                            ethereum.FilterQuery
+	votingSession                     *contract.TruSetCommitRevealVotingSession
+	boundContract                     *bind.BoundContract
+	from                              common.Address
 )
 
 func getLogTopic(eventSignature string) common.Hash {
-  return common.HexToHash("0x" + hex.EncodeToString(solsha3.SoliditySHA3(solsha3.String(eventSignature))))
+	return common.HexToHash("0x" + hex.EncodeToString(solsha3.SoliditySHA3(solsha3.String(eventSignature))))
 }
 
 var VoteCommittedLogTopic = getLogTopic("VoteCommitted(bytes32,address,bytes32)")
@@ -42,215 +42,215 @@ var RevealPeriodHaltedLogTopic = getLogTopic("RevealPeriodHalted(bytes32,address
 var PollCreatedLogTopic = getLogTopic("PollCreated(bytes32,address,uint256,uint256)")
 
 func revealTransactionOpts(client *ethclient.Client) *bind.TransactOpts {
-  key := os.Getenv("REVEALER_KEY")
-  passphrase := os.Getenv("REVEALER_PASSPHRASE")
-  auth, err := bind.NewTransactor(strings.NewReader(key), passphrase)
-  if err != nil {
-    log.Fatal(err)
-  }
-  return auth
+	key := os.Getenv("REVEALER_KEY")
+	passphrase := os.Getenv("REVEALER_PASSPHRASE")
+	auth, err := bind.NewTransactor(strings.NewReader(key), passphrase)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return auth
 }
 
 func Init(client *ethclient.Client, commitRevealVotingAddress string) {
-  commitRevealVotingContractAddress = common.HexToAddress(commitRevealVotingAddress)
+	commitRevealVotingContractAddress = common.HexToAddress(commitRevealVotingAddress)
 
-  filter = ethereum.FilterQuery{
-    Addresses: []common.Address{commitRevealVotingContractAddress},
-    FromBlock: big.NewInt(0),
-    ToBlock:   nil, // Latest block
-    Topics:    nil, // Match any topic, for testing
-    //Topics: [][]common.Hash{{
-    //RevealPeriodStartedLogTopic}},
-  }
+	filter = ethereum.FilterQuery{
+		Addresses: []common.Address{commitRevealVotingContractAddress},
+		FromBlock: big.NewInt(0),
+		ToBlock:   nil, // Latest block
+		Topics:    nil, // Match any topic, for testing
+		//Topics: [][]common.Hash{{
+		//RevealPeriodStartedLogTopic}},
+	}
 
-  votingContract, _ := contract.NewTruSetCommitRevealVoting(commitRevealVotingContractAddress, client)
-  opts := revealTransactionOpts(client)
+	votingContract, _ := contract.NewTruSetCommitRevealVoting(commitRevealVotingContractAddress, client)
+	opts := revealTransactionOpts(client)
 
-  votingSession = &contract.TruSetCommitRevealVotingSession{
-    Contract:     votingContract,
-    TransactOpts: *opts,
-  }
+	votingSession = &contract.TruSetCommitRevealVotingSession{
+		Contract:     votingContract,
+		TransactOpts: *opts,
+	}
 
-  from = opts.From
-  commitRevealVotingABI, _ := abi.JSON(strings.NewReader(contract.TruSetCommitRevealVotingABI))
-  boundContract = bind.NewBoundContract(commitRevealVotingContractAddress, commitRevealVotingABI, nil, nil, nil)
+	from = opts.From
+	commitRevealVotingABI, _ := abi.JSON(strings.NewReader(contract.TruSetCommitRevealVotingABI))
+	boundContract = bind.NewBoundContract(commitRevealVotingContractAddress, commitRevealVotingABI, nil, nil, nil)
 }
 
 func processLog(client *ethclient.Client, ctx context.Context, l types.Log) {
-  if l.Removed {
-    // TODO: need to handle chain re-organisations gracefully by undoing the affected database change!
-    // For now we expect this to be uncommon and would rather die than provide incorrect data
-    log.Fatalf("Found removed flag on log %+v", l)
-  }
+	if l.Removed {
+		// TODO: need to handle chain re-organisations gracefully by undoing the affected database change!
+		// For now we expect this to be uncommon and would rather die than provide incorrect data
+		log.Fatalf("Found removed flag on log %+v", l)
+	}
 
-  switch l.Topics[0] {
-  case RevealPeriodStartedLogTopic:
-    revealPeriodStarted := new(contract.TruSetCommitRevealVotingRevealPeriodStarted)
-    // shouldn't have to use this low level boundContract
-    boundContract.UnpackLog(revealPeriodStarted, "RevealPeriodStarted", l)
+	switch l.Topics[0] {
+	case RevealPeriodStartedLogTopic:
+		revealPeriodStarted := new(contract.TruSetCommitRevealVotingRevealPeriodStarted)
+		// shouldn't have to use this low level boundContract
+		boundContract.UnpackLog(revealPeriodStarted, "RevealPeriodStarted", l)
 
-    log.Printf("[Reveal Period Started]\t%s", hexutil.Encode(revealPeriodStarted.PollID[:]))
+		log.Printf("[Reveal Period Started]\t%s", hexutil.Encode(revealPeriodStarted.PollID[:]))
 
-    RevealCommitments(client, revealPeriodStarted)
-  case CommitPeriodHaltedLogTopic:
-    commitPeriodHalted := new(contract.TruSetCommitRevealVotingCommitPeriodHalted)
-    boundContract.UnpackLog(commitPeriodHalted, "CommitPeriodHalted", l)
+		RevealCommitments(client, revealPeriodStarted)
+	case CommitPeriodHaltedLogTopic:
+		commitPeriodHalted := new(contract.TruSetCommitRevealVotingCommitPeriodHalted)
+		boundContract.UnpackLog(commitPeriodHalted, "CommitPeriodHalted", l)
 
-    log.Printf("[Commit Period Halted]\t%s", hexutil.Encode(commitPeriodHalted.PollID[:]))
-  case RevealPeriodHaltedLogTopic:
-    revealPeriodHalted := new(contract.TruSetCommitRevealVotingRevealPeriodHalted)
-    boundContract.UnpackLog(revealPeriodHalted, "RevealPeriodHalted", l)
+		log.Printf("[Commit Period Halted]\t%s", hexutil.Encode(commitPeriodHalted.PollID[:]))
+	case RevealPeriodHaltedLogTopic:
+		revealPeriodHalted := new(contract.TruSetCommitRevealVotingRevealPeriodHalted)
+		boundContract.UnpackLog(revealPeriodHalted, "RevealPeriodHalted", l)
 
-    log.Printf("[Reveal Period Halted]\t%s", hexutil.Encode(revealPeriodHalted.PollID[:]))
-  case PollCreatedLogTopic:
-    pollCreated := new(contract.TruSetCommitRevealVotingPollCreated)
-    boundContract.UnpackLog(pollCreated, "PollCreated", l)
+		log.Printf("[Reveal Period Halted]\t%s", hexutil.Encode(revealPeriodHalted.PollID[:]))
+	case PollCreatedLogTopic:
+		pollCreated := new(contract.TruSetCommitRevealVotingPollCreated)
+		boundContract.UnpackLog(pollCreated, "PollCreated", l)
 
-    log.Printf("[Poll Created]\t%s", hexutil.Encode(pollCreated.PollID[:]))
-  case RevealPeriodHaltedLogTopic:
-    revealPeriodHalted := new(contract.TruSetCommitRevealVotingRevealPeriodHalted)
-    boundContract.UnpackLog(revealPeriodHalted, "RevealPeriodHalted", l)
+		log.Printf("[Poll Created]\t%s", hexutil.Encode(pollCreated.PollID[:]))
+	case RevealPeriodHaltedLogTopic:
+		revealPeriodHalted := new(contract.TruSetCommitRevealVotingRevealPeriodHalted)
+		boundContract.UnpackLog(revealPeriodHalted, "RevealPeriodHalted", l)
 
-    log.Printf("[Reveal Period Halted]\t%s", hexutil.Encode(revealPeriodHalted.PollID[:]))
-  case VoteCommittedLogTopic:
-    voteCommitted := new(contract.TruSetCommitRevealVotingVoteCommitted)
-    boundContract.UnpackLog(voteCommitted, "VoteCommitted", l)
+		log.Printf("[Reveal Period Halted]\t%s", hexutil.Encode(revealPeriodHalted.PollID[:]))
+	case VoteCommittedLogTopic:
+		voteCommitted := new(contract.TruSetCommitRevealVotingVoteCommitted)
+		boundContract.UnpackLog(voteCommitted, "VoteCommitted", l)
 
-    if knownCommitment(voteCommitted.PollID, voteCommitted.SecretHash) {
-      log.Printf("[Vote Committed] (recognised): %s : %s : %s", hexutil.Encode(voteCommitted.PollID[:]), voteCommitted.Voter.Hex(), hexutil.Encode(voteCommitted.SecretHash[:]))
-    } else {
-      log.Printf("[Vote Committed] UNRECOGNISED: %s : %s : %s", hexutil.Encode(voteCommitted.PollID[:]), voteCommitted.Voter.Hex(), hexutil.Encode(voteCommitted.SecretHash[:]))
-    }
+		if knownCommitment(voteCommitted.PollID, voteCommitted.SecretHash) {
+			log.Printf("[Vote Committed] (recognised): %s : %s : %s", hexutil.Encode(voteCommitted.PollID[:]), voteCommitted.Voter.Hex(), hexutil.Encode(voteCommitted.SecretHash[:]))
+		} else {
+			log.Printf("[Vote Committed] UNRECOGNISED: %s : %s : %s", hexutil.Encode(voteCommitted.PollID[:]), voteCommitted.Voter.Hex(), hexutil.Encode(voteCommitted.SecretHash[:]))
+		}
 
-  case VoteRevealedLogTopic:
-    voteRevealed := new(contract.TruSetCommitRevealVotingVoteRevealed)
-    boundContract.UnpackLog(voteRevealed, "VoteRevealed", l)
+	case VoteRevealedLogTopic:
+		voteRevealed := new(contract.TruSetCommitRevealVotingVoteRevealed)
+		boundContract.UnpackLog(voteRevealed, "VoteRevealed", l)
 
-    log.Printf("[Vote Revealed]\t%s : %s : %d", hexutil.Encode(voteRevealed.PollID[:]), voteRevealed.Voter.Hex(), voteRevealed.Choice)
-  default:
-    log.Printf("[Unexpected]\tlog with topics %x\n", l.Topics)
-    log.Println(l.Topics[0])
-  }
+		log.Printf("[Vote Revealed]\t%s : %s : %d", hexutil.Encode(voteRevealed.PollID[:]), voteRevealed.Voter.Hex(), voteRevealed.Choice)
+	default:
+		log.Printf("[Unexpected]\tlog with topics %x\n", l.Topics)
+		log.Println(l.Topics[0])
+	}
 }
 
 func fetchCommitments(pollID [32]byte) []database.Commitment {
-  var commitments []database.Commitment
-  database.Db.Where("poll_id = ?", hexutil.Encode(pollID[:])).Find(&commitments)
-  return commitments
+	var commitments []database.Commitment
+	database.Db.Where("poll_id = ?", hexutil.Encode(pollID[:])).Find(&commitments)
+	return commitments
 }
 
 func knownCommitment(pollID [32]byte, commitHash [32]byte) bool {
-  var commitments []database.Commitment
-  database.Db.Where("poll_id = ? and commit_hash = ?", hexutil.Encode(pollID[:]), hexutil.Encode(commitHash[:])).Find(&commitments)
-  return len(commitments) > 0
+	var commitments []database.Commitment
+	database.Db.Where("poll_id = ? and commit_hash = ?", hexutil.Encode(pollID[:]), hexutil.Encode(commitHash[:])).Find(&commitments)
+	return len(commitments) > 0
 }
 
 func logTrxResult(ctx context.Context, client *ethclient.Client, tx *types.Transaction, description string) {
-  receipt, err := bind.WaitMined(ctx, client, tx)
-  if err != nil || receipt.Status == 0 {
-    log.Printf("[%v FAILED] %+v %v %+v", description, err, receipt)
-  }
-  log.Printf("[%v Successful]", description)
+	receipt, err := bind.WaitMined(ctx, client, tx)
+	if err != nil || receipt.Status == 0 {
+		log.Printf("[%v FAILED] %+v %v %+v", description, err, receipt)
+	}
+	log.Printf("[%v Successful]", description)
 }
 
 func RevealCommitments(client *ethclient.Client, revealPeriodStarted *contract.TruSetCommitRevealVotingRevealPeriodStarted) {
-  commitments := fetchCommitments(revealPeriodStarted.PollID)
-  retryRevealsIndividually := false
+	commitments := fetchCommitments(revealPeriodStarted.PollID)
+	retryRevealsIndividually := false
 
-  // First try revealing all votes together.
-  var voters []common.Address
-  var voteOptions []*big.Int
-  var salts []*big.Int
-  for i := 0; i < len(commitments); i++ {
-    commitment := commitments[i]
-    voters = append(voters, common.HexToAddress(commitment.VoterAddress))
-    voteOptions = append(voteOptions, big.NewInt(int64(commitment.VoteOption)))
-    salts = append(salts, big.NewInt(int64(commitment.Salt)))
-  }
+	// First try revealing all votes together.
+	var voters []common.Address
+	var voteOptions []*big.Int
+	var salts []*big.Int
+	for i := 0; i < len(commitments); i++ {
+		commitment := commitments[i]
+		voters = append(voters, common.HexToAddress(commitment.VoterAddress))
+		voteOptions = append(voteOptions, big.NewInt(int64(commitment.VoteOption)))
+		salts = append(salts, big.NewInt(int64(commitment.Salt)))
+	}
 
-  trans, err := votingSession.RevealVotes(
-    revealPeriodStarted.InstrumentAddress,
-    revealPeriodStarted.DataIdentifier,
-    revealPeriodStarted.PayloadHash,
-    voters,
-    voteOptions,
-    salts,
-  )
+	trans, err := votingSession.RevealVotes(
+		revealPeriodStarted.InstrumentAddress,
+		revealPeriodStarted.DataIdentifier,
+		revealPeriodStarted.PayloadHash,
+		voters,
+		voteOptions,
+		salts,
+	)
 
-  if err != nil {
-    log.Printf("[Reveal-All Submission FAILED] %v", err)
-    retryRevealsIndividually = true
-  } else {
-    // TODO: here and elsewhere we want to use a cancellable context
-    //       this call will hang indefinitely until our transaction is mined or the context is cancelled
-    logTrxResult(context.Background(), client, trans, "Reveal-All Trx")
-  }
+	if err != nil {
+		log.Printf("[Reveal-All Submission FAILED] %v", err)
+		retryRevealsIndividually = true
+	} else {
+		// TODO: here and elsewhere we want to use a cancellable context
+		//       this call will hang indefinitely until our transaction is mined or the context is cancelled
+		logTrxResult(context.Background(), client, trans, "Reveal-All Trx")
+	}
 
-  // // If we could not reveal all votes together, fall back to revealing them individually
-  if retryRevealsIndividually {
-    for i := 0; i < len(commitments); i++ {
-      commitment := commitments[i]  
-      trans, err := votingSession.RevealVote(
-        revealPeriodStarted.InstrumentAddress,
-        revealPeriodStarted.DataIdentifier,
-        revealPeriodStarted.PayloadHash,
-        common.HexToAddress(commitment.VoterAddress),
-        big.NewInt(int64(commitment.VoteOption)),
-        big.NewInt(int64(commitment.Salt)),
-      )
-      if err != nil {
-        log.Printf("[Reveal Submission FAILED] %+v %v", commitment, err)
-      } else {
-        // TODO: here and elsewhere we want to use a cancellable context
-        //       this call will hang indefinitely until our transaction is mined or the context is cancelled
-        logTrxResult(context.Background(), client, trans, "Reveal Trx "+commitment.VoterAddress)
-      }
-    }
-  }
+	// // If we could not reveal all votes together, fall back to revealing them individually
+	if retryRevealsIndividually {
+		for i := 0; i < len(commitments); i++ {
+			commitment := commitments[i]
+			trans, err := votingSession.RevealVote(
+				revealPeriodStarted.InstrumentAddress,
+				revealPeriodStarted.DataIdentifier,
+				revealPeriodStarted.PayloadHash,
+				common.HexToAddress(commitment.VoterAddress),
+				big.NewInt(int64(commitment.VoteOption)),
+				big.NewInt(int64(commitment.Salt)),
+			)
+			if err != nil {
+				log.Printf("[Reveal Submission FAILED] %+v %v", commitment, err)
+			} else {
+				// TODO: here and elsewhere we want to use a cancellable context
+				//       this call will hang indefinitely until our transaction is mined or the context is cancelled
+				logTrxResult(context.Background(), client, trans, "Reveal Trx "+commitment.VoterAddress)
+			}
+		}
+	}
 }
 
 func ProcessPastEvents(client *ethclient.Client) {
-  ctx := context.Background()
+	ctx := context.Background()
 
-  // get past logs
-  logs, err := client.FilterLogs(context.Background(), filter)
-  if err != nil {
-    log.Fatal(err)
-    return
-  }
+	// get past logs
+	logs, err := client.FilterLogs(context.Background(), filter)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
 
-  for _, l := range logs {
-    processLog(client, ctx, l)
-  }
+	for _, l := range logs {
+		processLog(client, ctx, l)
+	}
 
-  log.Println("End of existing logs")
+	log.Println("End of existing logs")
 }
 
 func ProcessFutureEvents(client *ethclient.Client) {
-  ctx := context.Background()
-  log.Println("Log subscription starting")
+	ctx := context.Background()
+	log.Println("Log subscription starting")
 
-  // subscribe for new logs
-  // TODO: how to handle chain rollbacks and the resulting invalid logs? Probably monitor even status.
-  ch := make(chan types.Log, 100)
-  sub, err := client.SubscribeFilterLogs(ctx, filter, ch)
-  if err != nil {
-    log.Fatal(err)
-    return
-  }
+	// subscribe for new logs
+	// TODO: how to handle chain rollbacks and the resulting invalid logs? Probably monitor even status.
+	ch := make(chan types.Log, 100)
+	sub, err := client.SubscribeFilterLogs(ctx, filter, ch)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
 
-  defer sub.Unsubscribe()
-  errChan := sub.Err()
+	defer sub.Unsubscribe()
+	errChan := sub.Err()
 
-  for {
-    select {
-    case err := <-errChan:
-      log.Println("Logs subscription error", err)
-      break
-    case l := <-ch:
-      processLog(client, ctx, l)
-    }
-  }
+	for {
+		select {
+		case err := <-errChan:
+			log.Println("Logs subscription error", err)
+			break
+		case l := <-ch:
+			processLog(client, ctx, l)
+		}
+	}
 
-  log.Println("Log subscription terminated")
+	log.Println("Log subscription terminated")
 }

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/gin-gonic/gin"
 	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	_ "github.com/lib/pq"
@@ -45,13 +45,13 @@ func main() {
 
 	log.Println(fmt.Sprintf("Starting TruSet Revealer API server in %v mode...", *environment))
 	env := config.GetConfig()
-  // Try IPC, if configured
-  clientString = env.GetString("ethereumIpc")
+	// Try IPC, if configured
+	clientString = env.GetString("ethereumIpc")
 
-  if clientString == "" {
-    log.Println("Using websockets...")
-    clientString = env.GetString("ethereumWs")
-  }
+	if clientString == "" {
+		log.Println("Using websockets...")
+		clientString = env.GetString("ethereumWs")
+	}
 
 	client, err = ethclient.Dial(clientString)
 
@@ -63,9 +63,9 @@ func main() {
 	// Open a database connection, and close it when we are terminated
 	postgresUri := env.GetString("postgresUri")
 	if postgresUri == "" {
-    postgresUri = os.Getenv("DATABASE_URL")
-  }
-  db := SetupDB(postgresUri)
+		postgresUri = os.Getenv("DATABASE_URL")
+	}
+	db := SetupDB(postgresUri)
 	defer db.Close()
 	database.InitDb(db)
 
@@ -78,31 +78,31 @@ func main() {
 	events.Init(client, commitRevealVotingContractAddress)
 	//events.ProcessPastEvents(client)
 
-  go events.ProcessFutureEvents(client)
+	go events.ProcessFutureEvents(client)
 
 	// Run a REST server to serve TruSet API requests
 	r := SetupRouter()
-  r.Run(":"+*port) // listen and serve on 0.0.0.0:8080 by default
+	r.Run(":" + *port) // listen and serve on 0.0.0.0:8080 by default
 }
 
 func SetupDB(postgresUri string) *gorm.DB {
-  db, err := gorm.Open("postgres", postgresUri)
+	db, err := gorm.Open("postgres", postgresUri)
 	if err != nil {
 		log.Fatal(err)
 	}
-  return db
+	return db
 }
 
 func SetupRouter() *gin.Engine {
-  router := gin.Default()
+	router := gin.Default()
 
-  // TODO set cors
-  //config := cors.DefaultConfig()
-  //config.AllowOrigins = []string{"*"}
+	// TODO set cors
+	//config := cors.DefaultConfig()
+	//config.AllowOrigins = []string{"*"}
 
-  //router.Use(cors.New(config))
+	//router.Use(cors.New(config))
 
-  router.Use(cors.Default())
+	router.Use(cors.Default())
 	v1 := router.Group("/revealer/v0.1")
 	{
 		commitments := v1.Group("/commitments")
@@ -110,5 +110,5 @@ func SetupRouter() *gin.Engine {
 			commitments.POST("", database.StoreCommitment) // Supports /instruments?proposalstate=xyz
 		}
 	}
-  return router
+	return router
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,22 @@
 package main
+
 import (
-   "encoding/json"
-   "net/http"
-   "net/http/httptest"
-   "testing"
-   "fmt"
-   "log"
-   "math/big"
-   "github.com/jinzhu/gorm"
-   "github.com/gin-gonic/gin"
-   "github.com/stretchr/testify/assert"
-   "github.com/miguelmota/go-solidity-sha3"
-   "github.com/ethereum/go-ethereum/common/hexutil"
-   "github.com/TruSet/RevealerAPI/database"
-   "github.com/TruSet/RevealerAPI/config"
-   "bytes"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/TruSet/RevealerAPI/config"
+	"github.com/TruSet/RevealerAPI/database"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
+	"github.com/miguelmota/go-solidity-sha3"
+	"github.com/stretchr/testify/assert"
 )
 
 var db *gorm.DB
@@ -22,104 +24,102 @@ var router *gin.Engine
 
 func setupTest() {
 	config.Init("circleci")
-  env := config.GetConfig()
-  var postgresUri = env.GetString("postgresUri")
+	env := config.GetConfig()
+	var postgresUri = env.GetString("postgresUri")
 
-  router = SetupRouter()
-  db = SetupDB(postgresUri)
+	router = SetupRouter()
+	db = SetupDB(postgresUri)
 }
 
-
-func requestBodyBuffer(jsonStr string) (*bytes.Buffer) {
-   return bytes.NewBuffer([]byte(jsonStr))
+func requestBodyBuffer(jsonStr string) *bytes.Buffer {
+	return bytes.NewBuffer([]byte(jsonStr))
 }
 
 func TestInvalidCommitment(t *testing.T) {
-   setupTest()
-   database.InitDb(db)
-   test_voteOption := 1
-   test_salt := 666
-   test_pollID := "1234"
-   test_voterAddress := "0x1234"
+	setupTest()
+	database.InitDb(db)
+	test_voteOption := 1
+	test_salt := 666
+	test_pollID := "1234"
+	test_voterAddress := "0x1234"
 
-   var jsonStr = fmt.Sprintf(
-     "{\"pollID\":\"%s\", \"voterAddress\": \"%s\", \"commitHash\": \"%s\", \"voteOption\": %d, \"salt\": %d}",
-     test_pollID,
-     test_voterAddress,
-     "NotAValidCommitHash",
-     test_voteOption,
-     test_salt,
-   )
+	var jsonStr = fmt.Sprintf(
+		"{\"pollID\":\"%s\", \"voterAddress\": \"%s\", \"commitHash\": \"%s\", \"voteOption\": %d, \"salt\": %d}",
+		test_pollID,
+		test_voterAddress,
+		"NotAValidCommitHash",
+		test_voteOption,
+		test_salt,
+	)
 
-   req, _ := http.NewRequest("POST", "/revealer/v0.1/commitments", requestBodyBuffer(jsonStr))
-   req.Header.Set("Content-Type", "application/json")
+	req, _ := http.NewRequest("POST", "/revealer/v0.1/commitments", requestBodyBuffer(jsonStr))
+	req.Header.Set("Content-Type", "application/json")
 
-   w := httptest.NewRecorder()
-   router.ServeHTTP(w, req)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
 
-   // the request gives a 406
-   assert.Equal(t, http.StatusNotAcceptable, w.Code)
+	// the request gives a 406
+	assert.Equal(t, http.StatusNotAcceptable, w.Code)
 
 }
 
 func TestValidCommitment(t *testing.T) {
-   setupTest()
-   database.InitDb(db)
-   // Build our expected body
-   body := gin.H{
-      "status": http.StatusCreated,
-      "message": "vote will be revealed when voting closes",
-   }
+	setupTest()
+	database.InitDb(db)
+	// Build our expected body
+	body := gin.H{
+		"status":  http.StatusCreated,
+		"message": "vote will be revealed when voting closes",
+	}
 
-   test_voteOption := 1
-   test_salt := 666
-   test_pollID := "1234"
-   test_voterAddress := "0x1234"
+	test_voteOption := 1
+	test_salt := 666
+	test_pollID := "1234"
+	test_voterAddress := "0x1234"
 
-   test_commitHash := solsha3.SoliditySHA3(
-    solsha3.Uint256(big.NewInt(int64(test_voteOption))),
-    solsha3.Uint256(big.NewInt(int64(test_salt))),
-  )
+	test_commitHash := solsha3.SoliditySHA3(
+		solsha3.Uint256(big.NewInt(int64(test_voteOption))),
+		solsha3.Uint256(big.NewInt(int64(test_salt))),
+	)
 
-   var jsonStr = fmt.Sprintf(
-     "{\"pollID\":\"%s\", \"voterAddress\": \"%s\", \"commitHash\": \"%s\", \"voteOption\": %d, \"salt\": %d}",
-     test_pollID,
-     test_voterAddress,
-     hexutil.Encode(test_commitHash[:]),
-     test_voteOption,
-     test_salt,
-   )
+	var jsonStr = fmt.Sprintf(
+		"{\"pollID\":\"%s\", \"voterAddress\": \"%s\", \"commitHash\": \"%s\", \"voteOption\": %d, \"salt\": %d}",
+		test_pollID,
+		test_voterAddress,
+		hexutil.Encode(test_commitHash[:]),
+		test_voteOption,
+		test_salt,
+	)
 
-   req, _ := http.NewRequest("POST", "/revealer/v0.1/commitments", requestBodyBuffer(jsonStr))
-   req.Header.Set("Content-Type", "application/json")
+	req, _ := http.NewRequest("POST", "/revealer/v0.1/commitments", requestBodyBuffer(jsonStr))
+	req.Header.Set("Content-Type", "application/json")
 
-   w := httptest.NewRecorder()
-   router.ServeHTTP(w, req)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
 
-   // Assert we encoded correctly,
-   // the request gives a 200
-   assert.Equal(t, http.StatusCreated, w.Code)
-   // Convert the JSON response to a map
-   var response map[string]string
-   unmarshallErr := json.Unmarshal([]byte(w.Body.String()), &response)
+	// Assert we encoded correctly,
+	// the request gives a 200
+	assert.Equal(t, http.StatusCreated, w.Code)
+	// Convert the JSON response to a map
+	var response map[string]string
+	unmarshallErr := json.Unmarshal([]byte(w.Body.String()), &response)
 
-   // Grab the value & check whether or not it exists
-   value, exists := response["message"]
+	// Grab the value & check whether or not it exists
+	value, exists := response["message"]
 
-   // Make some assertions on the correctness of the response.
-   assert.Nil(t, unmarshallErr)
-   assert.True(t, exists)
-   assert.Equal(t, body["message"], value)
+	// Make some assertions on the correctness of the response.
+	assert.Nil(t, unmarshallErr)
+	assert.True(t, exists)
+	assert.Equal(t, body["message"], value)
 
+	var commitment database.Commitment
+	database.Db.Where(
+		"poll_id = ? and voter_address = ?",
+		test_pollID,
+		test_voterAddress,
+	).Last(&commitment)
+	log.Println(test_pollID, commitment.CommitHash, hexutil.Encode(test_commitHash[:]))
 
-   var commitment database.Commitment;
-   database.Db.Where(
-     "poll_id = ? and voter_address = ?",
-     test_pollID,
-     test_voterAddress,
-   ).Last(&commitment)
-   log.Println(test_pollID, commitment.CommitHash, hexutil.Encode(test_commitHash[:]))
-
-   assert.True(t, commitment.CommitHash == hexutil.Encode(test_commitHash[:]))
+	assert.True(t, commitment.CommitHash == hexutil.Encode(test_commitHash[:]))
 
 }


### PR DESCRIPTION
This commit contains no functional changes or refactoring, just formatting changes performed by standard tools. It should be safe to merge without an in-depth review. I will be basing my other changes on top of this so it would be good to get it in ASAP.

`goimport` is a superset of the almost-universally used formatter for go: `gofmt`. In addition to everything that `gofmt` does, `goimport` groups and orders imports, and automatically adds and removes them for you during development.

See instructions here for setting up `goimports` in your editor: https://godoc.org/golang.org/x/tools/cmd/goimports

To read more about `gofmt`, start here: https://blog.golang.org/go-fmt-your-code