### PR TITLE
separate worker service from api service

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
-web: RevealerAPI -e heroku -p $PORT
+web: RevealerAPI -e heroku -p $PORT -s api
+worker: RevealerAPI -e heroku -p $PORT --poll -s reveal


### PR DESCRIPTION
Adds a flag to allow the revealer api to either run as a rest server, or as a service worker
- `api` handles storing secrets
- `reveal` is a worker, that reveals votes as polls progress through stages

This has the advantage that it insulates the processes from each other.  For example, the worker could crash, and the rest api would continue to capture secrets while the worker restarted

Look out for corresponding changes on TruSet/TruSet